### PR TITLE
Poweroff fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ else
 endif
 EE_OBJS = main.o main_actions.o main_boot.o main_modules.o main_menu.o main_info_screens.o main_gameid.o main_history.o init.o main_startup.o main_fileops.o config.o config_screen.o config_startup.o config_network.o config_advanced.o gui.o gui_colors.o virtual_keyboard.o elf.o draw.o draw_gs.o draw_text.o loader_elf.o filer.o filer_device.o filer_mount.o filer_fileops.o filer_actions.o filer_browser.o filer_copy.o \
 	gui_sort.o gui_texteditor.o gui_hdd0_format.o psu_functions.o \
-	poweroff_irx.o iomanx_irx.o filexio_irx.o ps2dev9_irx.o \
+	poweroff_irx.o iomanx_irx.o filexio_irx.o ps2dev9_irx.o dev9_poweroff_irx.o \
 	ps2hdd_irx.o ps2fs_irx.o usbd_irx.o mcman_irx.o mcserv_irx.o \
 	cdvd_irx.o xparam_irx.o vmcman_irx.o ps2kbd_irx.o \
 	hdd.o hdl_rpc.o hdl_info_irx.o editor.o editor_menu.o editor_input.o editor_rules.o editor_file.o timer.o icon.o lang.o \
@@ -327,6 +327,7 @@ clean:
 	$(MAKE) -C iop/oldlibs/libcdvd clean
 	$(MAKE) -C iop/oldlibs/ps2ftpd clean
 	$(MAKE) -C iop/ps2hdd_osd clean
+	$(MAKE) -C iop/dev9_poweroff clean
 	@rm -f githash.h $(EE_BIN) $(EE_BIN_PKD)
 	@rm -rf $(EE_OBJS_DIR)
 	@rm -rf $(EE_ASM_DIR)

--- a/embed.make
+++ b/embed.make
@@ -474,6 +474,15 @@ $(EE_OBJS_DIR)vmcman_irx.o: $(EE_ASM_DIR)vmcman_irx.c | $(EE_OBJS_DIR)
 $(EE_ASM_DIR)ps2dev9_irx.s: $(PS2SDK)/iop/irx/ps2dev9.irx | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ ps2dev9_irx
 
+LOCAL_DEV9_POWEROFF_IRX := iop/dev9_poweroff/dev9_poweroff.irx
+DEV9_POWEROFF_DEPS := $(wildcard iop/dev9_poweroff/*.[ch]) iop/dev9_poweroff/imports.lst iop/dev9_poweroff/Makefile
+
+$(LOCAL_DEV9_POWEROFF_IRX): $(DEV9_POWEROFF_DEPS)
+	$(MAKE) -C iop/dev9_poweroff
+
+$(EE_ASM_DIR)dev9_poweroff_irx.s: $(LOCAL_DEV9_POWEROFF_IRX) | $(EE_ASM_DIR)
+	$(BIN2S) $< $@ dev9_poweroff_irx
+
 ifeq ($(ETH),1)
 $(EE_ASM_DIR)ps2ip_irx.s: $(PS2SDK)/iop/irx/ps2ip.irx | $(EE_ASM_DIR)
 	$(BIN2S) $< $@ ps2ip_irx

--- a/iop/dev9_poweroff/Makefile
+++ b/iop/dev9_poweroff/Makefile
@@ -1,0 +1,13 @@
+IOP_BIN = dev9_poweroff.irx
+IOP_OBJS = main.o imports.o
+
+IOP_CFLAGS += -Wall
+IOP_INCS += -I.
+
+all: $(IOP_BIN)
+
+clean:
+	-rm -f $(IOP_OBJS) $(IOP_BIN) $(IOP_BIN:.irx=.notiopmod.elf) $(IOP_BIN:.irx=.notiopmod.stripped.elf)
+
+include $(PS2SDK)/Defs.make
+include ../Rules.make

--- a/iop/dev9_poweroff/imports.lst
+++ b/iop/dev9_poweroff/imports.lst
@@ -1,0 +1,3 @@
+dev9_IMPORTS_start
+I_Dev9RegisterPowerOffHandler
+dev9_IMPORTS_end

--- a/iop/dev9_poweroff/irx_imports.h
+++ b/iop/dev9_poweroff/irx_imports.h
@@ -1,0 +1,7 @@
+#ifndef DEV9_POWEROFF_IRX_IMPORTS_H
+#define DEV9_POWEROFF_IRX_IMPORTS_H
+
+#include <irx.h>
+#include <dev9.h>
+
+#endif /* DEV9_POWEROFF_IRX_IMPORTS_H */

--- a/iop/dev9_poweroff/main.c
+++ b/iop/dev9_poweroff/main.c
@@ -1,0 +1,22 @@
+#include <irx.h>
+#include <loadcore.h>
+#include <dev9.h>
+
+IRX_ID("dev9_poweroff", 1, 0);
+
+int _start(int argc, char **argv)
+{
+	(void)argc;
+	(void)argv;
+
+	/*
+	 * APA registers slot 0 for SMART attribute saving and ATAD registers
+	 * slot 15 for STANDBY IMMEDIATE. PFS close has already handled the
+	 * filesystem side; these drive-maintenance callbacks can stall final
+	 * software poweroff for several seconds on some drives/adapters.
+	 */
+	Dev9RegisterPowerOffHandler(0, 0);
+	Dev9RegisterPowerOffHandler(15, 0);
+
+	return MODULE_NO_RESIDENT_END;
+}

--- a/src/init.c
+++ b/src/init.c
@@ -72,6 +72,7 @@ IMPORT_BIN2C(mmceman_irx);
 IMPORT_BIN2C(iomanx_irx);
 IMPORT_BIN2C(filexio_irx);
 IMPORT_BIN2C(ps2dev9_irx);
+IMPORT_BIN2C(dev9_poweroff_irx);
 IMPORT_BIN2C(vmcman_irx);
 IMPORT_BIN2C(ps2hdd_irx);
 IMPORT_BIN2C(ps2fs_irx);
@@ -203,6 +204,7 @@ extern u8 mx4sio_driver_running;
 static void delay(int count);
 static void initsbv_patches(void);
 static void load_ps2dev9(void);
+static void prepareDev9Poweroff(void);
 #ifdef ETH
 static void load_ps2ip(void);
 #endif
@@ -317,6 +319,19 @@ static void load_ps2dev9(void)
 }
 //------------------------------
 //endfunc load_ps2dev9
+//---------------------------------------------------------------------------
+static void prepareDev9Poweroff(void)
+{
+	int ret, ID __attribute__((unused));
+
+	if (!ps2dev9_loaded)
+		return;
+
+	ID = SifExecModuleBuffer(dev9_poweroff_irx, size_dev9_poweroff_irx, 0, NULL, &ret);
+	DPRINTF(" [DEV9_POWEROFF]: ID=%d, ret=%d\n", ID, ret);
+}
+//------------------------------
+//endfunc prepareDev9Poweroff
 //---------------------------------------------------------------------------
 #ifdef ETH
 static void load_ps2ip(void)
@@ -1473,6 +1488,7 @@ void closeAllAndPoweroff(void)
 #ifdef DVRP
 		fileXioDevctl("dvr_pfs:", PDIOC_CLOSEALL, NULL, 0, NULL, 0);
 #endif
+		prepareDev9Poweroff();
 		/* Switch off DEV9 */
 		while (fileXioDevctl("dev9x:", DDIOC_OFF, NULL, 0, NULL, 0) < 0) {
 		};

--- a/src/init.c
+++ b/src/init.c
@@ -205,6 +205,7 @@ static void delay(int count);
 static void initsbv_patches(void);
 static void load_ps2dev9(void);
 static void prepareDev9Poweroff(void);
+static void stopUsbMassForPoweroff(void);
 #ifdef ETH
 static void load_ps2ip(void);
 #endif
@@ -332,6 +333,29 @@ static void prepareDev9Poweroff(void)
 }
 //------------------------------
 //endfunc prepareDev9Poweroff
+//---------------------------------------------------------------------------
+static void stopUsbMassForPoweroff(void)
+{
+	if (!have_usb_mass)
+		return;
+
+#ifdef EXFAT
+	/*
+	 * With BDMFS active, "mass:" is the shared FAT device prefix. If ATA_BD
+	 * is mounted there, USBMASS_DEVCTL_STOP_ALL reaches ata_bd_stop(), which
+	 * sends an ATA standby command. After DEV9 shutdown that can sit until an
+	 * ATA timeout, so only use this legacy USB stop when ATA_BD is absent.
+	 */
+	if (have_ata_bd) {
+		DPRINTF(" [POWEROFF]: skipping mass stop while ATA_BD is active\n");
+		return;
+	}
+#endif
+
+	fileXioDevctl("mass:", USBMASS_DEVCTL_STOP_ALL, NULL, 0, NULL, 0);
+}
+//------------------------------
+//endfunc stopUsbMassForPoweroff
 //---------------------------------------------------------------------------
 #ifdef ETH
 static void load_ps2ip(void)
@@ -1494,8 +1518,8 @@ void closeAllAndPoweroff(void)
 		};
 	}
 
-	// As required by some (typically 2.5") HDDs, issue the SCSI STOP UNIT command to avoid causing an emergency park.
-	fileXioDevctl("mass:", USBMASS_DEVCTL_STOP_ALL, NULL, 0, NULL, 0);
+	// As required by some USB HDDs, issue the SCSI STOP UNIT command to avoid causing an emergency park.
+	stopUsbMassForPoweroff();
 
 	/* Power-off the PlayStation 2 console. */
 	poweroffShutdown();


### PR DESCRIPTION
Fix slow MISC/PS2PowerOff after loading HDD/ATA drivers

PowerOff could take 10-30 seconds after loading `hdd` or `ata`. The delay was not in the MISC menu path itself, which still matches upstream wLaunchELF’s flow. The issue came from this fork’s newer BDM/ATA stack: `mass:` is a shared BDMFS FAT prefix, so the legacy `USBMASS_DEVCTL_STOP_ALL` call could reach an ATA-backed block device and issue ATA standby/stop behavior after DEV9 had already been shut down. That could sit until an ATA timeout even when USB mass was never loaded.

Changes:
- Added a DEV9 poweroff helper to clear the known slow ATA/APA shutdown callbacks before `DDIOC_OFF`.
- Changed PowerOff’s mass-stop step to run only when USB mass was actually loaded.
- Skips the legacy `mass:` stop when `ata_bd` is active, avoiding ATA stop commands through BDMFS during final shutdown.

Manual result: PowerOff after loading HDD/ATA no longer waits ~30 seconds and returns to the expected fast shutdown behavior.